### PR TITLE
Fix Font Family, and add Font Weights styleguide

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -13,7 +13,7 @@ const Index = () => (
       justifyContent="center"
     >
       <Box>
-        <Heading fontSize="3xl" fontFamily="serif">
+        <Heading fontSize="3xl">
           A few words about this blog platform, Ghost, and how this site was
           made
         </Heading>

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,14 +1,15 @@
-import { extendTheme } from '@chakra-ui/react';
+import { extendTheme, theme as chakraTheme } from '@chakra-ui/react';
 import { createBreakpoints } from '@chakra-ui/theme-tools';
 import '@fontsource/fira-mono';
 import '@fontsource/noto-serif';
 import '@fontsource/open-sans';
 
 const fonts = {
-  heading: 'Noto Serif',
-  body: 'Noto Serif',
-  'sans-serif': 'Open Sans',
-  mono: 'Fira Mono',
+  ...chakraTheme.fonts,
+  heading: 'serif',
+  body: `Noto Serif, serif,-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol"`,
+  'sans-serif': 'Open Sans, sans-serif',
+  mono: 'Fira Mono, monospace',
 };
 
 const fontSizes = {
@@ -28,30 +29,17 @@ const breakpoints = createBreakpoints({
   xl: '80em',
 });
 
+const fontWeights = {
+  normal: 400,
+  medium: 500,
+  bold: 700,
+};
+
 const theme = extendTheme({
   fontSizes,
   fonts,
   breakpoints,
-  icons: {
-    logo: {
-      path: (
-        <svg
-          width="3000"
-          height="3163"
-          viewBox="0 0 3000 3163"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect width="3000" height="3162.95" fill="none" />
-          <path
-            d="M1470.89 1448.81L2170 2488.19H820V706.392H2170L1470.89 1448.81ZM1408.21 1515.37L909.196 2045.3V2393.46H1998.84L1408.21 1515.37Z"
-            fill="currentColor"
-          />
-        </svg>
-      ),
-      viewBox: '0 0 3000 3163',
-    },
-  },
+  fontWeights,
 });
 
 export default theme;


### PR DESCRIPTION
# Description
Fix font family buat heading lebih cocok pake serif, tambahin safe font buat body dan nambahin font weight.

Bug
![image](https://user-images.githubusercontent.com/52363719/119227499-60b57700-bb38-11eb-8baa-8ec3069a3c44.png)

Fix
![image](https://user-images.githubusercontent.com/52363719/119227516-71fe8380-bb38-11eb-9410-094cfb4520f3.png)

## Summary:
    -Change heading font family into serif (theme.js)
    -fix body font family, add font family for apple-system and other (theme.js),
    -add theme font weight normal (400), medium (500), bold (700) (theme.js)
    -for index js just delete Heading font family, to show which use serif
     and which one use sans-serif